### PR TITLE
phase 2: bug fixes, frontend unit tests, rework distribution view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
 bower_components
 static
+
+#
 .screenon
 .venv
+env
+
 *.db
+*.db.*
 *.csv
 *.json
+.idea
+screenon.egg-info

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,44 @@
+ScreenOn docs
+=============
+
+## Introduction
+
+ScreenOn is an application to measure and evaluate
+how much time someone is using their smartphone.
+
+Technically speaking, it is composed of two different
+software parts:
+
+* an Automate applet, running on the phone, recording screen usage data
+* a Flask.py+Polymer2 web application to access the data
+  and see several charts and statistics
+
+## Database
+
+### Create and update the database. 
+
+ScreenOn uses an SQLite3 database.
+The database can be created by invoking the following command:
+
+```
+$ sqlite3 screenon.db < screenon/schema.sql
+```
+
+The same command can be also used to apply schema changes,
+until we move to something more well-suited to this.
+The only recommendation is to **only add** commands to the schema file:
+don't modify the base table, but only alter tables using consecutive
+SQL DDL statements.
+
+## Development
+
+### Run browser tests
+
+To run tests, open a terminal and execute the following command:
+
+```
+polymer test
+```
+
+This command will start the predefined browser (eg Firefox) via Selenium,
+a library to run automated tests in a browser.

--- a/screenon/schema.sql
+++ b/screenon/schema.sql
@@ -2,3 +2,5 @@ create table if not exists screenon (
 	instant integer,
 	ison integer
 );
+
+create index if not exists screenon_time_idx on screenon (instant);

--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -8,7 +8,8 @@
     "px-tabs": "^2.1.2",
     "px-datetime-picker": "^2.2.1",
     "px-vis-timeseries": "^4.0.0",
-    "px-vis-xy-chart": "^4.0.0"
+    "px-vis-xy-chart": "^4.0.0",
+    "px-simple-horizontal-bar-chart": "^1.1.1"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",

--- a/webapp/src/data-loader/data-loader.html
+++ b/webapp/src/data-loader/data-loader.html
@@ -46,7 +46,7 @@
             }
 
             dataReceived(evt) {
-                let full_entries_list = evt.detail.response.response;
+                let full_entries_list = evt.detail.response ? evt.detail.response.response : [];
                 this.dispatchEvent(new CustomEvent('data-received', {
                     detail: fix_data(full_entries_list),
                     bubbles: true,
@@ -65,11 +65,13 @@
                     current_instant = current_instant + Math.random() * 1000;
                     current_status = !current_status;
                 }
-                this.dispatchEvent(new CustomEvent('data-received', {
-                    detail: fix_data(full_entries_list),
-                    bubbles: true,
-                    composed: true
-                }));
+                setTimeout(() => {
+                    this.dispatchEvent(new CustomEvent('data-received', {
+                        detail: fix_data(full_entries_list),
+                        bubbles: true,
+                        composed: true
+                    }));
+                }, 5000);
             }
         }
 

--- a/webapp/src/data_handling.js
+++ b/webapp/src/data_handling.js
@@ -1,23 +1,28 @@
 const turned_off = (on_off) => on_off === false;
+const turned_on = (on_off) => on_off === true;
 
 function cumulated_time(data) {
-  let cumulated = [];
-  let currentTotal = 0;
-  let last_entry = null;
-  cumulated.push({instant: data[0].instant, value: 0});
-  data.forEach(entry => {
-    if(turned_off(entry.on_off)) {
-	// TODO: for the time being, we decide to ignore the time before
-	// the first screen change event if the screen was ON
-	if(last_entry !== null) {
-	  const delta = entry.instant - last_entry.instant;
-	  currentTotal += delta;
-	  cumulated.push({instant: entry.instant, value: currentTotal});
-	}
+    if(data.length === 0) {
+        return [];
     }
-    last_entry = entry;
-  });
-  return cumulated;
+
+    let cumulated = [];
+    let currentTotal = 0;
+    let firstIsOff = turned_off(data[0].on_off);
+    let realData = firstIsOff ? data.slice(1) : data;
+    cumulated.push({instant: data[0].instant, value: 0});
+    for(let i=0; i<realData.length-1; i+=1) {
+        if(turned_on(realData[i].on_off)) {
+            let delta = realData[i+1].instant - realData[i].instant;
+            cumulated.push({instant: realData[i+1].instant, value: currentTotal + delta});
+            currentTotal += delta;
+        }
+        else {
+            cumulated.push({instant: realData[i+1].instant, value: currentTotal});
+        }
+    }
+
+    return cumulated;
 }
 
 function _group_by(data, ranges_number, time_format) {

--- a/webapp/src/data_handling.js
+++ b/webapp/src/data_handling.js
@@ -80,51 +80,54 @@ function filter_by_day(data, requested_day) {
   return result;
 }
 
+// @Assumption: records inside `data` are sorted by instant in ascending order
 function merge_consecutive_entries(data) {
-  return data.reduce((prev, entry) => {
-    if(prev.length === 0) return [entry];
+    return data.reduce((prev, entry) => {
+        if (prev.length === 0) return [entry];
 
-    const last_pos = prev.length - 1;
-    if(prev[last_pos].on_off === entry.on_off) {
-	// console.log(prev[last_pos].instant, entry.instant);
-        prev[last_pos].instant = entry.instant;
-    }
-    else {
-        prev.push(entry);
-    }
-    return prev;
-  }, []);
+        const last_pos = prev.length - 1;
+        if (prev[last_pos].on_off !== entry.on_off) {
+            prev.push(entry);
+        }
+        return prev;
+    }, []);
 }
 
 function fix_data(data) {
-  let merged_data = merge_consecutive_entries(data);
+    let sorted_data = data.sort((a_rec, b_rec) => a_rec.instant - b_rec.instant);
 
-  // group entries by day
-  let grouped_by_day = {};
-  merged_data.forEach(entry => {
-    let day = moment.unix(entry.instant).format("YYYY MM DD");
-    if(grouped_by_day[day]) {
-      grouped_by_day[day].push(entry);
-    }
-    else {
-      grouped_by_day[day] = [entry];
-    }
-  });
+    let merged_data = merge_consecutive_entries(sorted_data);
 
-  // add entries at midnight
-  Object.keys(grouped_by_day).forEach((day, i) => {
-    // TODO: replace this condition with fake "opposite" entry(?)
-    if(i === 0) return;
+    // group entries by day
+    let grouped_by_day = {};
+    merged_data.forEach(entry => {
+        let day = moment.unix(entry.instant).format("YYYY MM DD");
+        if (grouped_by_day[day]) {
+            grouped_by_day[day].push(entry);
+        }
+        else {
+            grouped_by_day[day] = [entry];
+        }
+    });
 
-    // not using moment.utc here because timestamps on server are not utc
-    let midnight = moment(day, "YYYY MM DD");
-    let previous_day_entries = grouped_by_day[Object.keys(grouped_by_day)[i-1]];
-    let last_entry_of_previous_day = previous_day_entries[previous_day_entries.length-1];
-    grouped_by_day[day].splice(0, 0, {instant: midnight.valueOf()/1000, on_off: last_entry_of_previous_day.on_off});
-  });
+    // add entries at midnight
+    let days = Object.keys(grouped_by_day).sort();
+    days.forEach((day, i) => {
+        if (i === 0) return;
 
-  // flatten
-  return Object.values(grouped_by_day).reduce((result, entries) => result.concat(entries), []);
+        // not using moment.utc here because timestamps on server are not utc
+        let midnight = moment(day, "YYYY MM DD").startOf("day");
+        let previous_day_entries = grouped_by_day[days[i - 1]];
+        let last_entry_of_previous_day = previous_day_entries[previous_day_entries.length - 1];
+        grouped_by_day[day].splice(0, 0, {
+            instant: midnight.valueOf() / 1000,
+            on_off: last_entry_of_previous_day.on_off,
+            new_: true
+        });
+    });
+
+    // flatten
+    return Object.values(grouped_by_day).reduce((result, entries) => result.concat(entries), []);
 }
 
 function duration_distribution(single_day_data) {

--- a/webapp/src/data_handling.js
+++ b/webapp/src/data_handling.js
@@ -1,6 +1,7 @@
 const turned_off = (on_off) => on_off === false;
 const turned_on = (on_off) => on_off === true;
 
+// Note that all records in `data` should be of the same day.
 function cumulated_time(data) {
     if(data.length === 0) {
         return [];
@@ -8,8 +9,7 @@ function cumulated_time(data) {
 
     let cumulated = [];
     let currentTotal = 0;
-    let firstIsOff = turned_off(data[0].on_off);
-    let realData = firstIsOff ? data.slice(1) : data;
+    let realData = data;
     cumulated.push({instant: data[0].instant, value: 0});
     for(let i=0; i<realData.length-1; i+=1) {
         if(turned_on(realData[i].on_off)) {
@@ -110,16 +110,16 @@ function fix_data(data) {
         }
     });
 
-    // add entries at midnight
+    // add entries at midnight (end of day)
     let days = Object.keys(grouped_by_day).sort();
     days.forEach((day, i) => {
-        if (i === 0) return;
+        if (i === (days.length-1)) return;
 
         // not using moment.utc here because timestamps on server are not utc
-        let midnight = moment(day, "YYYY MM DD").startOf("day");
-        let previous_day_entries = grouped_by_day[days[i - 1]];
-        let last_entry_of_previous_day = previous_day_entries[previous_day_entries.length - 1];
-        grouped_by_day[day].splice(0, 0, {
+        let midnight = moment(day, "YYYY MM DD").endOf("day");
+        let entries = grouped_by_day[day];
+        let last_entry_of_previous_day = entries[entries.length - 1];
+        grouped_by_day[day].push({
             instant: midnight.valueOf() / 1000,
             on_off: last_entry_of_previous_day.on_off,
             new_: true

--- a/webapp/src/distribution-chart/distribution-chart.html
+++ b/webapp/src/distribution-chart/distribution-chart.html
@@ -1,34 +1,46 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/px-vis-xy-chart/px-vis-xy-chart.html">
+<link rel="import" href="../../bower_components/px-simple-horizontal-bar-chart/px-simple-horizontal-bar-chart.html">
 
 <dom-module id="distribution-chart">
     <template>
-        <button on-click="switch_chart_type">Switch to [[chartType]] chart</button>
-        <i>The <b>Logarithmic chart</b> will compress time deltas over 60 seconds, leaving more space
-            for intervals under 60 seconds. Switch to this type of chart to better appreciate short-time usages.
-            <b>Normal chart</b>, instead, won't perform any kind of compression on data. It is better suited
-            to explore the distribution of longer usage intervals.</i>
-        <px-vis-xy-chart
-                chart-data="[[chartData]]"
-                show-tooltip
-                hide-register
-                series-config="[[seriesConfig]]"></px-vis-xy-chart>
-        <table>
-            <thead>
-            <tr>
-                <th>time</th>
-                <th>hits</th>
-            </tr>
-            </thead>
-            <tbody>
-            <template is="dom-repeat" items="[[chartData]]">
-                <tr>
-                    <td>time: [[item.delta]]s</td>
-                    <td>hits: [[item.hits]]</td>
-                </tr>
-            </template>
-            </tbody>
-        </table>
+        <style>
+            :root {
+                --px-vis-series-color-0: #31aa2c;
+                --px-vis-series-color-1: #bbac2e;
+                --px-vis-series-color-2: #cc902a;
+                --px-vis-series-color-3: #dd6344;
+                --px-vis-series-color-4: #dd529d;
+                --px-vis-series-color-5: #9358dd;
+            }
+        </style>
+        <p>
+        This view is composed by two charts:
+        <ul>
+        <li>the left one shows how many times you interacted with the phone, grouped by time intervals</li>
+        <li>the right one shows the real time you spent on the phone</li>
+        </ul>
+        The values are either shown as percentages (when followed by %) or seconds.
+        For now, there is no drill-down or matrix-style chart to show the usage at different times (while at work/school
+        or during lunch break): the results are based on the whole day.
+        </p>
+        <br />
+        <button on-click="switch_chart_type">Switch to [[otherChartType]]</button>
+        <br />
+        <px-simple-horizontal-bar-chart
+                width="600"
+                height="400"
+                bar-labels=[[chartType]]
+                legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
+                chart-data=[[chartData]]
+        ></px-simple-horizontal-bar-chart>
+        <px-simple-horizontal-bar-chart
+                width="600"
+                height="400"
+                bar-labels=[[chartType]]
+                legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
+                chart-data=[[cumulatedChartData]]
+        ></px-simple-horizontal-bar-chart>
     </template>
 
     <script>
@@ -44,53 +56,71 @@
             static get properties() {
                 return {
                     data: {type: Array, observer: "_dataChanged"},
-                    chartType: {type: String, value: "Normal"},
-                    isLog: {type: Boolean, value: true}
+                    chartType: {type: String, value: "values"},
+                    otherChartType: {type: String, value: "percentage"},
                 };
             }
 
             switch_chart_type() {
-                if (this.chartType === "Logarithmic") {
-                    this.set("chartType", "Normal");
-                    this.set("isLog", true);
+                if (this.chartType === "values") {
+                    this.set("chartType", "percentage");
+                    this.set("otherChartType", "values");
                 }
                 else {
-                    this.set("chartType", "Logarithmic");
-                    this.set("isLog", false);
+                    this.set("chartType", "values");
+                    this.set("otherChartType", "percentage");
                 }
                 this._dataChanged(this.data);
             }
 
             _dataChanged(new_data) {
-                console.log("distribution-chart", "dataChanged", new_data);
                 if (!new_data) {
                     this.set("chartData", []);
                 }
                 else {
-                    this.set("chartData", new_data
-                        .map(entry => {
-                            return {
-                                x: this.isLog ? Math.log(new Number(entry.delta)) / Math.log(60) : new Number(entry.delta),
-                                y: entry.hits,
-                                delta: new Number(entry.delta),
-                                hits: entry.hits
-                            }
-                        }).sort((a, b) => a.delta - b.delta));
+                    let isPercentage = this.chartType === "percentage";
 
+                    let counter = 0;
+                    let result = [0, 0, 0, 0, 0, 0];
+                    let sumCounter = 0;
+                    let sumResult = [0, 0, 0, 0, 0, 0];
+                    new_data.forEach(record => {
+                        // legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
+                        let index = -1;
+                        if(record.delta < 5) {
+                            index = 0;
+                        }
+                        else if(record.delta <= 10) {
+                            index = 1;
+                        }
+                        else if(record.delta <= 30) {
+                            index = 2
+                        }
+                        else if(record.delta <= 60) {
+                            index = 3
+                        }
+                        else if(record.delta <= 300) {
+                            index = 4
+                        }
+                        else {
+                            index = 5;
+                        }
+                        counter += record.hits;
+                        result[index] += record.hits;
+                        sumCounter += record.delta * record.hits;
+                        sumResult[index] += record.delta * record.hits;
+                    });
+
+                    if(isPercentage) {
+                        result = result.map(num => Math.round((num/counter)*100));
+                        sumResult = sumResult.map(num => Math.round((num/sumCounter)*100));
+                    }
+
+                    this.set("chartData", result);
+                    this.set("cumulatedChartData", sumResult);
                 }
-                this.set("seriesConfig", {
-                    "deltaHits": {
-                        type: "scatter",
-                        name: "hits of duration",
-                        x: "x",
-                        y: "y",
-                        "axis": {"id": "axis1", "side": "left", "number": "1"}
-                    },
-                });
             }
-
         }
-
         window.customElements.define(DistributionChart.is, DistributionChart);
     </script>
 </dom-module>

--- a/webapp/src/distribution-chart/distribution-chart.html
+++ b/webapp/src/distribution-chart/distribution-chart.html
@@ -25,22 +25,28 @@
         or during lunch break): the results are based on the whole day.
         </p>
         <br />
-        <button on-click="switch_chart_type">Switch to [[otherChartType]]</button>
-        <br />
-        <px-simple-horizontal-bar-chart
-                width="600"
-                height="400"
-                bar-labels=[[chartType]]
-                legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
-                chart-data=[[chartData]]
-        ></px-simple-horizontal-bar-chart>
-        <px-simple-horizontal-bar-chart
-                width="600"
-                height="400"
-                bar-labels=[[chartType]]
-                legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
-                chart-data=[[cumulatedChartData]]
-        ></px-simple-horizontal-bar-chart>
+        <template is="dom-if" if="[[_dataSelected]]">
+            <button on-click="switch_chart_type">Switch to [[otherChartType]]</button>
+            <br />
+            <px-simple-horizontal-bar-chart
+                    width="600"
+                    height="400"
+                    bar-labels=[[chartType]]
+                    legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
+                    chart-data=[[chartData]]
+            ></px-simple-horizontal-bar-chart>
+            <px-simple-horizontal-bar-chart
+                    width="600"
+                    height="400"
+                    bar-labels=[[chartType]]
+                    legend-labels='["<5s","5-10s","10-30s","30-60s","60-300s",">300s"]'
+                    chart-data=[[cumulatedChartData]]
+            ></px-simple-horizontal-bar-chart>
+        </template>
+        <template is="dom-if" if="[[!_dataSelected]]">
+            <b>To see the charts, please select a day from the single day selector in the top part
+            of the application</b>
+        </template>
     </template>
 
     <script>
@@ -56,6 +62,9 @@
             static get properties() {
                 return {
                     data: {type: Array, observer: "_dataChanged"},
+                    _dataSelected: {type: Boolean, value: false},
+                    chartData: {type: Array, value: []},
+                    cumulatedChartData: {type: Array, value: []},
                     chartType: {type: String, value: "values"},
                     otherChartType: {type: String, value: "percentage"},
                 };
@@ -118,6 +127,7 @@
 
                     this.set("chartData", result);
                     this.set("cumulatedChartData", sumResult);
+                    this.set("_dataSelected", true);
                 }
             }
         }

--- a/webapp/src/screen-on-app/screen-on-app.html
+++ b/webapp/src/screen-on-app/screen-on-app.html
@@ -191,8 +191,7 @@
             fill_cumulated(evt) {
                 const index = evt.detail.index;
                 const day = this.grouped_per_day[index].interval;
-                // this.cumulated_per_day = cumulated_time(filter_by_day(this.formatted_json, day));
-                this.cumulated_per_day = unfiltered_cumulated_time(filter_by_day(this.formatted_json, day));
+                this.cumulated_per_day = cumulated_time(filter_by_day(this.formatted_json, day));
             }
 
             fill_distribution(evt) {

--- a/webapp/src/screen-on-app/screen-on-app.html
+++ b/webapp/src/screen-on-app/screen-on-app.html
@@ -6,7 +6,7 @@
 <link rel="import" href="../data-loader/data-loader.html">
 <link rel="import" href="../cumulated-chart/cumulated-chart.html">
 <link rel="import" href="../distribution-chart/distribution-chart.html">
-<link rel="import" href="screen-on-range-picker.html" />
+<link rel="import" href="screen-on-range-picker.html"/>
 <script src="../data_handling.js"></script>
 
 <dom-module id="screen-on-app">
@@ -14,6 +14,18 @@
         <style>
             :host {
                 display: block;
+            }
+
+            .no-data {
+                min-height: 70vh;
+                width: 100%;
+                display: flex;
+                align-items: center;
+            }
+
+            .no-data p {
+                text-align: center;
+                width: 100%;
             }
         </style>
         <h2>Screen-On - how much are you using your phone?</h2>
@@ -41,29 +53,46 @@
                 <px-tab id="tab3">Distribution of phone usage</px-tab>
             </px-tabs>
             <iron-pages selected="[[selected_chart]]">
-                <div id="tab1-content" style="height: 600px">
-                    <cumulated-chart data="[[cumulated_per_day]]"></cumulated-chart>
-                </div>
-                <div id="tab2-content" style="height: 600px">
-                    <px-vis-timeseries
-                            x-axis-type="timeLocal"
-                            tooltip-config="[[timezoneConfig]]"
-                            register-config="[[timezoneConfig]]"
-                            chart-data="[[chartData]]"
-                            height="350"
-                            show-tooltip
-                            hide-register
-                            series-config="[[seriesConfig]]">
-                    </px-vis-timeseries>
-                </div>
-                <div id="tab3-content" style="height: 600px">
-                    <distribution-chart data="[[distribution_per_day]]"></distribution-chart>
-                </div>
+                <template is="dom-if" if="[[!show_loading]]">
+                    <div id="tab1-content" style="height: 600px">
+                        <cumulated-chart data="[[cumulated_per_day]]"></cumulated-chart>
+                    </div>
+                    <div id="tab2-content" style="height: 600px">
+                        <px-vis-timeseries
+                                x-axis-type="timeLocal"
+                                tooltip-config="[[timezoneConfig]]"
+                                register-config="[[timezoneConfig]]"
+                                chart-data="[[chartData]]"
+                                height="350"
+                                show-tooltip
+                                hide-register
+                                series-config="[[seriesConfig]]">
+                        </px-vis-timeseries>
+                    </div>
+                    <div id="tab3-content" style="height: 600px">
+                        <distribution-chart data="[[distribution_per_day]]"></distribution-chart>
+                    </div>
+                </template>
             </iron-pages>
-            <template is="dom-if" if="[[show_loading]]">
-                <div>[[loading_text]]</div>
-            </template>
         </div>
+        <template is="dom-if" if="[[show_loading]]">
+            <div class="no-data">
+                <template is="dom-if" if="[[!show_help_message]]">
+                    <p>Loading...</p>
+                </template>
+                <template is="dom-if" if="[[show_help_message]]">
+                    <div style="margin: auto; text-align: center; padding: 0 20%;">
+                        <b>No data in the requested interval</b>
+                        <br/>
+                        <p>
+                            There are two reasons for this: either you did not
+                            use the phone during that time (unlikely? :P), or you did not
+                            upload your phone usage data.
+                        </p>
+                    </div>
+                </template>
+            </div>
+        </template>
     </template>
     <script>
         /**
@@ -93,6 +122,9 @@
                     show_loading: {
                         type: Boolean, value: true
                     },
+                    show_help_message: {
+                        type: Boolean, value: false
+                    },
                     loading_text: {
                         type: String, value: "Loading..."
                     },
@@ -109,10 +141,11 @@
             fill_table(evt) {
                 console.log(evt);
                 let formatted_json = evt.detail;
-                if(formatted_json.length === 0) {
+                if (formatted_json.length === 0) {
                     // stop here, as there are no data.
                     this.set("show_loading", true);
-                    this.set("loading_text", "No data in the requested time interval");
+                    this.set("show_help_message", true);
+                    // this.set("loading_text", "No data in the requested time interval");
                     return;
                 }
                 this.set("show_loading", false);
@@ -158,7 +191,8 @@
             fill_cumulated(evt) {
                 const index = evt.detail.index;
                 const day = this.grouped_per_day[index].interval;
-                this.cumulated_per_day = cumulated_time(filter_by_day(this.formatted_json, day));
+                // this.cumulated_per_day = cumulated_time(filter_by_day(this.formatted_json, day));
+                this.cumulated_per_day = unfiltered_cumulated_time(filter_by_day(this.formatted_json, day));
             }
 
             fill_distribution(evt) {

--- a/webapp/src/screen-on-app/screen-on-range-picker.html
+++ b/webapp/src/screen-on-app/screen-on-range-picker.html
@@ -20,8 +20,8 @@
                 date-format="YYYY/MM/DD"
                 from-moment="[[minDate]]"
                 to-moment="[[maxDate]]"
-                min-date="{{minDateStr}}"
-                max-date="{{maxDateStr}}"
+                min-date="[[minDateStr]]"
+                max-date="[[maxDateStr]]"
                 on-px-datetime-range-submitted="update_selected_range"></px-rangepicker>
     </template>
     <script>
@@ -40,23 +40,28 @@
                 };
             }
 
+            setShownTime() {
+                let today = moment().endOf("day");
+                let one_week_ago = moment().subtract(7, "days").startOf("day");
+                this.set("minDate", one_week_ago);
+                this.set("maxDate", today);
+            }
+
             dataReceived(evt) {
                 let raw_data = evt.detail.response;
                 let first_moment = moment.unix(raw_data.first_instant).startOf("day");
                 let last_moment = moment.unix(raw_data.last_instant).endOf("day");
 
-                this.set("minDate", first_moment);
-                this.set("maxDate", last_moment);
+                this.setShownTime();
                 this.set("minDateStr", first_moment.toISOString());
                 this.set("maxDateStr", last_moment.toISOString());
             }
 
             mockReceived(evt) {
-                let startOf = moment().subtract(7, "days").startOf("day");
+                let startOf = moment().subtract(50, "days").startOf("day");
                 let endOf = moment().endOf("day");
 
-                this.set("minDate", startOf);
-                this.set("maxDate", endOf);
+                this.setShownTime();
                 this.set("minDateStr", startOf.toISOString());
                 this.set("maxDateStr", endOf.toISOString());
                 console.log(this.get("minDateStr"), this.get("maxDateStr"));

--- a/webapp/test/data-handling/data-handling_test.html
+++ b/webapp/test/data-handling/data-handling_test.html
@@ -15,18 +15,18 @@
 <body>
 <script>
     suite("cumulated_time", () => {
-        test("empty array", function() {
+        test("empty array", function () {
             assert.deepEqual(cumulated_time([]), []);
         });
 
-        test("`value` contains instant deltas", () => {
+        test("start from `true`", () => {
             let START = 12345;
             let input = [
                 {instant: START, on_off: true},
-                {instant: START+10, on_off: false},
-                {instant: START+50, on_off: true},
-                {instant: START+100, on_off: false},
-                {instant: START+200, on_off: true}
+                {instant: START + 10, on_off: false},
+                {instant: START + 50, on_off: true},
+                {instant: START + 100, on_off: false},
+                {instant: START + 200, on_off: true}
             ];
 
             let result = cumulated_time(input);
@@ -35,15 +35,242 @@
                 // t0
                 {instant: START, value: 0},
                 // t1
-                {instant: START+10, value: 10},
+                {instant: START + 10, value: 10},
                 // t2
-                {instant: START+50, value: 10},
+                {instant: START + 50, value: 10},
                 // t3
-                {instant: START+100, value: 60},
+                {instant: START + 100, value: 60},
                 // t4
-                {instant: START+200, value: 60}
+                {instant: START + 200, value: 60}
+            ]);
+        });
+
+        test("start from `false`", () => {
+            let START = 12345;
+            let input = [
+                {instant: START, on_off: false},
+                {instant: START + 10, on_off: true},
+                {instant: START + 50, on_off: false},
+                {instant: START + 100, on_off: true},
+                {instant: START + 200, on_off: false}
+            ];
+
+            let result = cumulated_time(input);
+            // console.error(result.map(x => JSON.stringify(x)).join(","));
+
+            assert.deepEqual(result, [
+                // t0
+                {instant: START, value: 0},
+                // t1 is ignored, as the first value is false.
+                // {instant: START + 10, value: 0},
+                // t2
+                {instant: START + 50, value: 40},
+                // t3
+                {instant: START + 100, value: 40},
+                // t4
+                {instant: START + 200, value: 140}
             ]);
         })
+    });
+
+    suite("merge_consecutive_entries", () => {
+        test("handles empty array and one item array", () => {
+            assert.deepEqual(merge_consecutive_entries([]), []);
+            assert.deepEqual(merge_consecutive_entries([
+                {instant: 123, on_off: true}
+            ]), [
+                {instant: 123, on_off: true}
+            ]);
+        });
+
+        test("no repeated statuses", () => {
+            let input = [
+                {instant: 1, on_off: true},
+                {instant: 2, on_off: false},
+                {instant: 3, on_off: true},
+                {instant: 4, on_off: false},
+                {instant: 5, on_off: true},
+                {instant: 6, on_off: false}
+            ];
+
+            assert.deepEqual(merge_consecutive_entries(input), input);
+        });
+
+        test("repeated statuses", () => {
+            let input = [
+                {instant: 1, on_off: true},
+                {instant: 2, on_off: false},
+                {instant: 3, on_off: true},
+                {instant: 4, on_off: true},
+                {instant: 5, on_off: true},
+                {instant: 6, on_off: false},
+                {instant: 7, on_off: false},
+                {instant: 8, on_off: true},
+                {instant: 9, on_off: false},
+                {instant: 10, on_off: false},
+                {instant: 11, on_off: false}
+            ];
+            let expected = [
+                {instant: 1, on_off: true},
+                {instant: 2, on_off: false},
+                {instant: 3, on_off: true},
+                {instant: 6, on_off: false},
+                {instant: 8, on_off: true},
+                {instant: 9, on_off: false}
+            ];
+
+            let result = merge_consecutive_entries(input);
+
+            assert.deepEqual(result, expected);
+        });
+    });
+
+    let duplicatedRecords = function (result) {
+        const cache = result
+            .map(hit => hit.instant)
+            .reduce((prev, instant) => {
+                prev[instant] = prev[instant] ? prev[instant] + 1 : 1;
+                return prev;
+            }, {});
+        return Object.keys(cache)
+            .filter((cache_key) => {
+                return cache[cache_key] > 1;
+            }).length;
+    };
+
+    let indexOfInstant = function(records, instant) {
+        let index = 0;
+        while(index < records.length) {
+            if(records[index].instant === instant) {
+                return index;
+            }
+            index += 1;
+        }
+        return -1;
+    };
+
+    suite("fix_data", () => {
+        test("is robust against unsorted records", () => {
+            const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
+            let input = [
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false}, // 2nd
+                {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false}, // 4th
+                {instant: morning_dayTwo, on_off: true}, // 3rd
+                {instant: morning_dayOne, on_off: true}  // 1st
+            ].map(hit => {
+                return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            assert.deepEqual(result.map(rec => rec.on_off), [true, false, false, true, false]);
+        });
+
+        test("midnight records are not added to the first day of data", () => {
+            const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
+            let input = [
+                {instant: morning_dayOne, on_off: true},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+                {instant: morning_dayTwo, on_off: true},
+                {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
+            ].map(hit => {
+                return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            // the midnight record is not added to the first day in the period
+            assert.equal(result[0].instant, input[0].instant);
+        });
+
+        test("adds midnight records", () => {
+            const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
+            let input = [
+                {instant: morning_dayOne, on_off: true},
+                {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+                {instant: morning_dayTwo, on_off: true},
+                {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
+            ].map(hit => {
+                return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            // there is one more item (the midnight record)
+            assert.equal(result.length, input.length+1);
+
+            // the midnight record is added before the morning of the second day
+            let midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+            assert.ok(midnightRecordIndex !== -1, "there should be a midnight record here!");
+            // the status of the midnight record should be false (from 2200 day 1, it changes 0005 day 2)
+            assert.ok(!result[midnightRecordIndex].on_off, "the midnight record should be `false`");
+            assert.ok(result[midnightRecordIndex+1].on_off, "the first record after midnight should be `true`");
+
+            // there are no duplicated records
+            let duplicatedInstantsInFixedData = duplicatedRecords(result);
+            assert.equal(duplicatedInstantsInFixedData, 0, "there should be no repeated midnight!");
+        });
+
+        //
+    //     test("midnight screen change", () => {
+    //         assert.ok(false, "write me!");
+    //
+    //         const morning_dayOne = moment().startOf("day").add(6, "minutes");
+    //         const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
+    //         let input = [
+    //             {instant: morning_dayOne, on_off: true},
+    //             {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
+    //             {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
+    //             {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+    //             {instant: morning_dayTwo, on_off: true},
+    //             {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
+    //         ].map(hit => {
+    //             return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+    //         });
+    //         let result = fix_data(input);
+    //
+    //         let resultLen = result.length;
+    //         assert.equal(result.length, input.length+1);
+    //         assert.equal(result[0].instant, input[0].instant);
+    //         assert.equal(result[resultLen-1-2].instant, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+    //
+    //         const cache = result
+    //                 .map(hit => hit.instant)
+    //                 .reduce((prev, instant) => {
+    //                     prev[instant] = prev[instant] ? prev[instant]+1 : 1;
+    //                     return prev;
+    //                 }, {});
+    //         const duplicatedInstantsInFixedData = Object.keys(cache)
+    //             .filter((cache_key) => {
+    //                 return cache[cache_key] > 1;
+    //             }).length;
+    //         assert.equal(duplicatedInstantsInFixedData, 0, "there should be no repeated midnight (day 2)!");
+    //     });
+    //
+
+        test("if cross-day usage, midnight record does not modify on_off status", () => {
+            const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
+            let input = [
+                {instant: morning_dayOne, on_off: true},
+                {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(23, "hours").add(10, "minutes"), on_off: true},
+                {instant: morning_dayTwo, on_off: false}
+            ].map(hit => {
+                return {instant: hit.instant.valueOf() / 1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            let midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+            assert.ok(midnightRecordIndex !== -1, "there should a be midnight here!");
+            assert.equal(result[midnightRecordIndex].on_off, true, "cross-day usage ==> no change!");
+            assert.equal(result[midnightRecordIndex-1].on_off, true, "the record before midnight should be `true`");
+            assert.equal(result[midnightRecordIndex+1].on_off, false, "the record after midnight should be `false`");
+        });
     });
 </script>
 </body>

--- a/webapp/test/data-handling/data-handling_test.html
+++ b/webapp/test/data-handling/data-handling_test.html
@@ -56,13 +56,12 @@
             ];
 
             let result = cumulated_time(input);
-            // console.error(result.map(x => JSON.stringify(x)).join(","));
 
             assert.deepEqual(result, [
                 // t0
                 {instant: START, value: 0},
-                // t1 is ignored, as the first value is false.
-                // {instant: START + 10, value: 0},
+                // t1
+                {instant: START + 10, value: 0},
                 // t2
                 {instant: START + 50, value: 40},
                 // t3
@@ -70,7 +69,35 @@
                 // t4
                 {instant: START + 200, value: 140}
             ]);
-        })
+        });
+
+        test("day ending with turned on screen", () => {
+            const morning_dayOne = moment().startOf("day");
+            let input = [
+                {instant: morning_dayOne, on_off: false},
+                {instant: morning_dayOne.clone().add(12, "hours"), on_off: true},
+                {instant: morning_dayOne.clone().add(18, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: true},
+                // 1 hour after second day's midnight. needed to let `fix_data` generate the end-of-day record
+                // needed for the test
+                {instant: morning_dayOne.clone().add(25, "hours"), on_off: false}
+            ].map(hit => {
+                return {instant: hit.instant.valueOf() / 1000, on_off: hit.on_off};
+            });
+            let fixedInput = fix_data(input);
+
+            let dayOneRecords = fixedInput.slice(0, -1);
+            assert.equal(dayOneRecords.length, 5);
+            let result = cumulated_time(dayOneRecords);
+            // compare seconds as integers - use `floor` to convert floats
+            assert.deepEqual(result.map(ct => Math.floor(ct.value)), [
+                0, /*start of day*/
+                0, /*12 hours*/
+                6*60*60, /*18 hours*/
+                6*60*60, /*22 hours*/
+                6*60*60 + (60*60 + 59*60 + 59) /*end of day*/
+            ]);
+        });
     });
 
     suite("merge_consecutive_entries", () => {
@@ -166,7 +193,7 @@
             assert.deepEqual(result.map(rec => rec.on_off), [true, false, false, true, false]);
         });
 
-        test("does not add midnight records to the first day of data", () => {
+        test("adds midnight records to the first day of data, but not to last", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");
             const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
             let input = [
@@ -178,9 +205,15 @@
                 return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
             });
             let result = fix_data(input);
+            let lastInput = input.length - 1;
+            let last = result.length - 1;
 
-            // the midnight record is not added to the first day in the period
             assert.equal(result[0].instant, input[0].instant);
+            // the last record of first day is midnight record
+            assert.equal(result[2].instant, morning_dayOne.clone().endOf("day").valueOf()/1000);
+            // the last record of second day is not midnight record
+            assert.notEqual(result[last].instant, morning_dayTwo.clone().endOf("day").valueOf()/1000);
+            assert.equal(result[last].instant, input[lastInput].instant);
         });
 
         test("adds midnight records", () => {
@@ -202,7 +235,7 @@
             assert.equal(result.length, input.length+1);
 
             // the midnight record is added before the morning of the second day
-            let midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+            let midnightRecordIndex = indexOfInstant(result, morning_dayOne.clone().endOf("day").valueOf()/1000);
             assert.ok(midnightRecordIndex !== -1, "there should be a midnight record here!");
             // the status of the midnight record should be false (from 2200 day 1, it changes 0005 day 2)
             assert.ok(!result[midnightRecordIndex].on_off, "the midnight record should be `false`");
@@ -228,10 +261,7 @@
             });
             let result = fix_data(input);
 
-            const duplicatedInstantsInFixedData = duplicatedRecords(result);
-            assert.equal(duplicatedInstantsInFixedData, 1, "there should be a repeated midnight (day 2)!");
-
-            const midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().valueOf()/1000);
+            const midnightRecordIndex = indexOfInstant(result, morning_dayOne.clone().endOf("day").valueOf()/1000);
             assert.equal(result[midnightRecordIndex].on_off, !result[midnightRecordIndex+1].on_off, "the two midnight records should be different");
             assert.equal(result[midnightRecordIndex].on_off, false, "the new midnight record should be _before_ the legit one");
         });
@@ -251,12 +281,13 @@
             });
             let result = fix_data(input);
 
-            let midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+            let midnightRecordIndex = indexOfInstant(result, morning_dayOne.clone().endOf("day").valueOf()/1000);
             assert.ok(midnightRecordIndex !== -1, "there should a be midnight here!");
             assert.equal(result[midnightRecordIndex].on_off, true, "cross-day usage ==> no change!");
             assert.equal(result[midnightRecordIndex-1].on_off, true, "the record before midnight should be `true`");
             assert.equal(result[midnightRecordIndex+1].on_off, false, "the record after midnight should be `false`");
         });
+
     });
 </script>
 </body>

--- a/webapp/test/data-handling/data-handling_test.html
+++ b/webapp/test/data-handling/data-handling_test.html
@@ -166,7 +166,7 @@
             assert.deepEqual(result.map(rec => rec.on_off), [true, false, false, true, false]);
         });
 
-        test("midnight records are not added to the first day of data", () => {
+        test("does not add midnight records to the first day of data", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");
             const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
             let input = [
@@ -213,42 +213,28 @@
             assert.equal(duplicatedInstantsInFixedData, 0, "there should be no repeated midnight!");
         });
 
-        //
-    //     test("midnight screen change", () => {
-    //         assert.ok(false, "write me!");
-    //
-    //         const morning_dayOne = moment().startOf("day").add(6, "minutes");
-    //         const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
-    //         let input = [
-    //             {instant: morning_dayOne, on_off: true},
-    //             {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
-    //             {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
-    //             {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
-    //             {instant: morning_dayTwo, on_off: true},
-    //             {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
-    //         ].map(hit => {
-    //             return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
-    //         });
-    //         let result = fix_data(input);
-    //
-    //         let resultLen = result.length;
-    //         assert.equal(result.length, input.length+1);
-    //         assert.equal(result[0].instant, input[0].instant);
-    //         assert.equal(result[resultLen-1-2].instant, morning_dayTwo.clone().startOf("day").valueOf()/1000);
-    //
-    //         const cache = result
-    //                 .map(hit => hit.instant)
-    //                 .reduce((prev, instant) => {
-    //                     prev[instant] = prev[instant] ? prev[instant]+1 : 1;
-    //                     return prev;
-    //                 }, {});
-    //         const duplicatedInstantsInFixedData = Object.keys(cache)
-    //             .filter((cache_key) => {
-    //                 return cache[cache_key] > 1;
-    //             }).length;
-    //         assert.equal(duplicatedInstantsInFixedData, 0, "there should be no repeated midnight (day 2)!");
-    //     });
-    //
+        test("midnight screen change", () => {
+            const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day");
+            let input = [
+                {instant: morning_dayOne, on_off: true},
+                {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+                {instant: morning_dayTwo, on_off: true},
+                {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
+            ].map(hit => {
+                return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            const duplicatedInstantsInFixedData = duplicatedRecords(result);
+            assert.equal(duplicatedInstantsInFixedData, 1, "there should be a repeated midnight (day 2)!");
+
+            const midnightRecordIndex = indexOfInstant(result, morning_dayTwo.clone().valueOf()/1000);
+            assert.equal(result[midnightRecordIndex].on_off, !result[midnightRecordIndex+1].on_off, "the two midnight records should be different");
+            assert.equal(result[midnightRecordIndex].on_off, false, "the new midnight record should be _before_ the legit one");
+        });
 
         test("if cross-day usage, midnight record does not modify on_off status", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");

--- a/webapp/test/data-handling/data-handling_test.html
+++ b/webapp/test/data-handling/data-handling_test.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>screen-on-app test</title>
+
+    <script src="../../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+
+    <script src="../../src/data_handling.js"></script>
+    <script src="../../src/../bower_components/moment/moment.js"></script>
+</head>
+<body>
+<script>
+    suite("cumulated_time", () => {
+        test("empty array", function() {
+            assert.deepEqual(cumulated_time([]), []);
+        });
+
+        test("`value` contains instant deltas", () => {
+            let START = 12345;
+            let input = [
+                {instant: START, on_off: true},
+                {instant: START+10, on_off: false},
+                {instant: START+50, on_off: true},
+                {instant: START+100, on_off: false},
+                {instant: START+200, on_off: true}
+            ];
+
+            let result = cumulated_time(input);
+
+            assert.deepEqual(result, [
+                // t0
+                {instant: START, value: 0},
+                // t1
+                {instant: START+10, value: 10},
+                // t2
+                {instant: START+50, value: 10},
+                // t3
+                {instant: START+100, value: 60},
+                // t4
+                {instant: START+200, value: 60}
+            ]);
+        })
+    });
+</script>
+</body>
+</html>

--- a/webapp/test/data-handling/data-handling_test.html
+++ b/webapp/test/data-handling/data-handling_test.html
@@ -86,7 +86,7 @@
             });
             let fixedInput = fix_data(input);
 
-            let dayOneRecords = fixedInput.slice(0, -1);
+            let dayOneRecords = fixedInput.slice(0, -2);
             assert.equal(dayOneRecords.length, 5);
             let result = cumulated_time(dayOneRecords);
             // compare seconds as integers - use `floor` to convert floats
@@ -190,10 +190,17 @@
             });
             let result = fix_data(input);
 
-            assert.deepEqual(result.map(rec => rec.on_off), [true, false, false, true, false]);
+            assert.deepEqual(result.map(rec => rec.on_off), [
+                true,  // 1st
+                false, // 2nd
+                false, // end of day
+                false, // start of next day
+                true,  // 3rd
+                false  // 4th
+            ]);
         });
 
-        test("adds midnight records to the first day of data, but not to last", () => {
+        test("adds end of day records to the first day of data, but not to last", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");
             const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
             let input = [
@@ -231,22 +238,24 @@
             });
             let result = fix_data(input);
 
-            // there is one more item (the midnight record)
-            assert.equal(result.length, input.length+1);
+            // there are two more item (the midnight records)
+            assert.equal(result.length, input.length+2);
 
             // the midnight record is added before the morning of the second day
             let midnightRecordIndex = indexOfInstant(result, morning_dayOne.clone().endOf("day").valueOf()/1000);
             assert.ok(midnightRecordIndex !== -1, "there should be a midnight record here!");
-            // the status of the midnight record should be false (from 2200 day 1, it changes 0005 day 2)
             assert.ok(!result[midnightRecordIndex].on_off, "the midnight record should be `false`");
-            assert.ok(result[midnightRecordIndex+1].on_off, "the first record after midnight should be `true`");
+            assert.equal(result[midnightRecordIndex+1].instant, morning_dayTwo.clone().startOf("day").valueOf()/1000);
+            assert.ok(!result[midnightRecordIndex+1].on_off, "the first record after midnight should be `false` too (start of day)");
+            // the status of the midnight record should be false (from 2200 day 1, it changes 0005 day 2)
+            assert.ok(result[midnightRecordIndex+2].on_off, "the first real record after midnight should be `true`");
 
             // there are no duplicated records
             let duplicatedInstantsInFixedData = duplicatedRecords(result);
             assert.equal(duplicatedInstantsInFixedData, 0, "there should be no repeated midnight!");
         });
 
-        test("midnight screen change", () => {
+        test("end of day midnight screen change", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");
             const morning_dayTwo = moment().startOf("day").add(1, "day");
             let input = [
@@ -266,7 +275,25 @@
             assert.equal(result[midnightRecordIndex].on_off, false, "the new midnight record should be _before_ the legit one");
         });
 
-        test("if cross-day usage, midnight record does not modify on_off status", () => {
+        test("no duplicated start of day records", () => {
+           const morning_dayOne = moment().startOf("day").add(6, "minutes");
+            const morning_dayTwo = moment().startOf("day").add(1, "day");
+            let input = [
+                {instant: morning_dayOne, on_off: true},
+                {instant: morning_dayOne.clone().add(12, "hours"), on_off: false},
+                {instant: morning_dayOne.clone().add(18, "hours"), on_off: true},
+                {instant: morning_dayOne.clone().add(22, "hours"), on_off: false},
+                {instant: morning_dayTwo, on_off: true},
+                {instant: morning_dayTwo.clone().add(12, "hours"), on_off: false},
+            ].map(hit => {
+                return {instant: hit.instant.valueOf()/1000, on_off: hit.on_off};
+            });
+            let result = fix_data(input);
+
+            assert.equal(duplicatedRecords(result), 0, "there should be no duplicated records!");
+        });
+
+        test("if cross-day usage, `end of day` midnight record does not modify on_off status", () => {
             const morning_dayOne = moment().startOf("day").add(6, "minutes");
             const morning_dayTwo = moment().startOf("day").add(1, "day").add(5, "minutes");
             let input = [
@@ -285,9 +312,9 @@
             assert.ok(midnightRecordIndex !== -1, "there should a be midnight here!");
             assert.equal(result[midnightRecordIndex].on_off, true, "cross-day usage ==> no change!");
             assert.equal(result[midnightRecordIndex-1].on_off, true, "the record before midnight should be `true`");
-            assert.equal(result[midnightRecordIndex+1].on_off, false, "the record after midnight should be `false`");
+            assert.equal(result[midnightRecordIndex+1].on_off, true, "start of next day record should be `true`");
+            assert.equal(result[midnightRecordIndex+2].on_off, false, "the record after midnight should be `false`");
         });
-
     });
 </script>
 </body>


### PR DESCRIPTION
This batch of changes does not bring a lot of changes to the application. I took some time to fix some stuff before starting to work on new features and data visualization/fusion tasks.
The biggest change here is the distribution view: the scatter chart is now replaced by an horizontal bar chart. I found the scatter chart hard to read and (maybe) wrong too, so I replaced it with a standard visualization that better highlights the usage classes and the time I actually spent on the phone (real data below!)

![image](https://user-images.githubusercontent.com/1429402/46910053-d3e8bc80-cf3d-11e8-9357-ae51185bb9b3.png)


Backend changes:
* add index on `screenon` table

Frontend changes:
* automatically load data from a week ago to today
* handle "no data" case in distribution view and daily usage view
* write tests for client-side data manipulation functions
* rework distribution view: replace scatter chart with horizontal bar chart to show classes of usage (under 5 seconds, 5-10 seconds, 10-30 seconds, 30 seconds to one minute, 1-5 minutes, over 5 minutes)

Misc:
* create a minimal "docs" document